### PR TITLE
 Adds disableOtherPlayerRendering and fixes duplicate zoom config (#71)

### DIFF
--- a/src/main/java/fi/dy/masa/tweakeroo/config/Configs.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/config/Configs.java
@@ -216,7 +216,6 @@ public class Configs implements IConfigHandler
                 SNAP_AIM_THRESHOLD_YAW,
                 SNAP_AIM_YAW_STEP,
                 STRUCTURE_BLOCK_MAX_SIZE,
-                ZOOM_FOV,
                 DAY_CYCLE_OVERRIDE_TIME,
                 WEATHER_OVERRIDE_OPTION,
                 SCAFFOLD_PLACE_DISTANCE,
@@ -330,7 +329,7 @@ public class Configs implements IConfigHandler
         public static final ConfigBooleanHotkeyed       DISABLE_BAT_SPAWNING            = new ConfigBooleanClient  ("disableBatSpawning",                   false, "", "Disables Bat spawning in single player");
         public static final ConfigBooleanHotkeyed       DISABLE_BEACON_BEAM_RENDERING   = new ConfigBooleanHotkeyed("disableBeaconBeamRendering",           false, "", "Disables Beacon beam rendering");
         public static final ConfigBooleanHotkeyed       DISABLE_BLOCK_BREAK_PARTICLES   = new ConfigBooleanHotkeyed("disableBlockBreakingParticles",        false, "", "Removes the block breaking particles.\n(This is originally from usefulmod by nessie.)");
-        public static final ConfigBooleanHotkeyed       DISABLE_CLIENT_BLOCK_EVENTS     = new ConfigBooleanHotkeyed("disableClientBlockEvents",           false, "", "Disables block event rendering (eg pistons animations)");
+        public static final ConfigBooleanHotkeyed       DISABLE_CLIENT_BLOCK_EVENTS     = new ConfigBooleanHotkeyed("disableClientBlockEvents",             false, "", "Disables block event rendering (eg pistons animations)");
         public static final ConfigBooleanHotkeyed       DISABLE_DOUBLE_TAP_SPRINT       = new ConfigBooleanHotkeyed("disableDoubleTapSprint",               false, "", "Disables the double-tap-forward-key sprinting");
         public static final ConfigBooleanHotkeyed       DISABLE_BOSS_BAR                = new ConfigBooleanHotkeyed("disableBossBar",                       false, "", "Disables boss bar rendering");
         public static final ConfigBooleanHotkeyed       DISABLE_BOSS_FOG                = new ConfigBooleanHotkeyed("disableBossFog",                       false, "", "Removes the fog that boss mobs cause");
@@ -355,6 +354,7 @@ public class Configs implements IConfigHandler
         public static final ConfigBooleanHotkeyed       DISABLE_OBSERVER                = new ConfigBooleanClient  ("disableObserver",                      false, "", "Disable Observers from triggering at all");
         public static final ConfigBooleanHotkeyed       DISABLE_OFFHAND_RENDERING       = new ConfigBooleanHotkeyed("disableOffhandRendering",              false, "", "Disables the offhand item from getting rendered");
         public static final ConfigBooleanHotkeyed       DISABLE_PARTICLES               = new ConfigBooleanHotkeyed("disableParticles",                     false, "", "Disables all particles");
+        public static final ConfigBooleanHotkeyed       DISABLE_OTHER_PLAYER_RENDERING  = new ConfigBooleanHotkeyed("disableOtherPlayerRendering",          false, "", "Disables rendering of all players except yourself");
         public static final ConfigBooleanHotkeyed       DISABLE_PORTAL_GUI_CLOSING      = new ConfigBooleanHotkeyed("disablePortalGuiClosing",              false, "", "If enabled, then you can still open GUIs while in a Nether Portal");
         public static final ConfigBooleanHotkeyed       DISABLE_RAIN_EFFECTS            = new ConfigBooleanHotkeyed("disableRainEffects",                   false, "", "Disables rain rendering and sounds");
         public static final ConfigBooleanHotkeyed       DISABLE_RENDERING_SCAFFOLDING   = new ConfigBooleanHotkeyed("disableRenderingScaffolding",          false, "", "Disables rendering of Scaffolding Blocks");
@@ -406,6 +406,7 @@ public class Configs implements IConfigHandler
                 DISABLE_OBSERVER,
                 DISABLE_OFFHAND_RENDERING,
                 DISABLE_PARTICLES,
+                DISABLE_OTHER_PLAYER_RENDERING,
                 DISABLE_PORTAL_GUI_CLOSING,
                 DISABLE_RAIN_EFFECTS,
                 DISABLE_RENDERING_SCAFFOLDING,

--- a/src/main/java/fi/dy/masa/tweakeroo/config/Hotkeys.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/config/Hotkeys.java
@@ -106,7 +106,6 @@ public class Hotkeys
             TOGGLE_CARPET_AP_PROTOCOL,
             TOGGLE_GRAB_CURSOR,
             TOOL_PICK,
-            ZOOM_ACTIVATE,
             AREA_SELECTION_OFFSET,
             AREA_SELECTION_ADD_TO_LIST,
             AREA_SELECTION_REMOVE_FROM_LIST,

--- a/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinEntityRenderDispatcher.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinEntityRenderDispatcher.java
@@ -40,6 +40,11 @@ public abstract class MixinEntityRenderDispatcher
         {
             cir.setReturnValue(false);
         }
+        
+        if (Configs.Disable.DISABLE_OTHER_PLAYER_RENDERING.getBooleanValue() && isPlayer && !((PlayerEntity)entityIn).isMainPlayer())
+        {
+            cir.setReturnValue(false);
+        }
 
         if (FeatureToggle.TWEAK_RENDER_ALL_ENTITIES.getBooleanValue())
         {


### PR DESCRIPTION
* Added a function to reset the AFK timer whenever the AFK interval is changed by the player. Prevented AFK timer from resetting from periodic attacks.

* Update README.md to add info about AFK fixes

* Update README.md AFK information

* Added feature to change noteblock note by scolling

* notePlayKey feature & Configs

Added notePlayKey feature to play current noteblock note (useful for creative). Added config options to toggle notePlayKey and noteScroll.

* added afkInputIgnore. Potential fix to gamma override

* possible gamma fix? no 2

* fixed noteKeyPlay and gamma override

noteKeyPlay works using mouse buttons and gamma override will stay on after relogging.

* fixed notePlayKey again

* notePlayKey does not activate while sneaking

* prevented notePlayKey with sneaking w/ scroll

* Update README.md

* fixed issue with inventory preview

* small change to noteblock tab key

* updated to 1.20.4

* Update README.md

* Fixed afk timer not resetting as of v1.3.0

* Fix player rendering error with freecam (#69).

Merges ANGEL_BLOCK_PLACEMENT_DISTANCE from tweakeroo (4850652) Merges snapshot 23w33a changes from tweakeroo (218b322)

* Adds disableOtherPlayerRendering and fixes duplicate zoom config